### PR TITLE
Minor fix in triangle example

### DIFF
--- a/examples/src/bin/triangle.rs
+++ b/examples/src/bin/triangle.rs
@@ -306,7 +306,7 @@ fn main() {
                     .iter()
                     .map(|sc_image| {
                         Arc::new(
-                            Framebuffer::start(triangle_renderpass.clone())
+                            Framebuffer::start(merge_renderpass.clone())
                                 .add(sc_image.clone())
                                 .unwrap()
                                 .build()
@@ -362,7 +362,7 @@ fn main() {
                             (),
                             iter::empty()
                         ).unwrap()
-                        
+
                         .end_render_pass().unwrap();
 
                     let (mut cmd_buf, basalt_img) = itf_renderer.draw(


### PR DESCRIPTION
The merge renderpass should be given as argument to build the merge
framebuffer. It works now because images have the same layout but if you
do something different like MSAA on the triangle renderpass it will
break.
