### PR TITLE
fix 02703 & 02699 validiation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 0.16.1 (July 25th, 2022)
+
+- Fixed `VUID-vkCmdDraw-None-02703` & `VUID-vkCmdDraw-None-02699` validation errors.
+
 # Version 0.16.0 (July 20th, 2022)
 
 - **BREAKING** Update dependency `vulkano` & `vulkano-shaders` to `0.30`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "basalt"
 edition = "2021"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Austin <me@austinj.me>"]
 repository = "https://github.com/AustinJ235/basalt"
 documentation = "https://docs.rs/basalt"

--- a/src/interface/render/layer_fs.rs
+++ b/src/interface/render/layer_fs.rs
@@ -46,10 +46,10 @@ pub mod layer_fs {
 		vec4 s = vec4(xcubic.xz + xcubic.yw, ycubic.xz + ycubic.yw);
 		vec4 offset = c + vec4 (xcubic.yw, ycubic.yw) / s;
 		offset *= invTexSize.xxyy;
-		vec4 sample0 = texture(tex_nearest[tex_i], offset.xz);
-		vec4 sample1 = texture(tex_nearest[tex_i], offset.yz);
-		vec4 sample2 = texture(tex_nearest[tex_i], offset.xw);
-		vec4 sample3 = texture(tex_nearest[tex_i], offset.yw);
+		vec4 sample0 = textureLod(tex_nearest[tex_i], offset.xz, 0);
+		vec4 sample1 = textureLod(tex_nearest[tex_i], offset.yz, 0);
+		vec4 sample2 = textureLod(tex_nearest[tex_i], offset.xw, 0);
+		vec4 sample3 = textureLod(tex_nearest[tex_i], offset.yw, 0);
 		float sx = s.x / (s.x + s.y);
 		float sy = s.z / (s.z + s.w);
 		return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
@@ -88,7 +88,7 @@ pub mod layer_fs {
 			out_std_rgba(clamp(textureBicubic(coords) * color, 0.0, 1.0));
 		}
 		else if(type == 2) { // Glyph
-			vec3 mask = texture(tex_nearest[tex_i], coords).rgb;
+			vec3 mask = textureLod(tex_nearest[tex_i], coords, 0).rgb;
 
 			if(mask.r <= epsilon && mask.g <= epsilon && mask.b <= epsilon) {
 				discard;


### PR DESCRIPTION
``
[Basalt][VkDebug][Layer: VUID-vkCmdDraw-None-02703][Severity: Error][Type: Validation]: Validation Error: [ VUID-vkCmdDraw-None-02703 ] Object 0: handle = 0x13105e0000000155, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 1: handle = 0x8e6ca10000000135, type = VK_OBJECT_TYPE_IMAGE_VIEW; Object 2: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_SAMPLER; | MessageID = 0x57d08217 | Descriptor set VkDescriptorSet 0x13105e0000000155[] encountered the following validation error at vkCmdDraw time: VkImageView 0x8e6ca10000000135[] in Descriptor in binding #2 index 0 is used by VkSampler 0xf56c9b0000000004[] that uses invalid operator. The Vulkan spec states: If the VkPipeline object bound to the pipeline bind point used by this command accesses a VkSampler object that uses unnormalized coordinates, that sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample* instructions with ImplicitLod, Dref or Proj in their name, in any shader stage (https://vulkan.lunarg.com/doc/view/1.3.211.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDraw-None-02703)
``

**Caused by using `texture` instead of `textureLod` with an unnormalized sampler.**

``
[Basalt][VkDebug][Layer: VUID-vkCmdDraw-None-02699][Severity: Error][Type: Validation]: Validation Error: [ VUID-vkCmdDraw-None-02699 ] Object 0: handle = 0x13105e0000000155, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; | MessageID = 0x1608dec0 | Descriptor set VkDescriptorSet 0x13105e0000000155[] encountered the following validation error at vkCmdDraw time: Descriptor in binding #2 index 1 is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call. The Vulkan spec states: Descriptors in each bound descriptor set, specified via vkCmdBindDescriptorSets, must be valid if they are statically used by the VkPipeline bound to the pipeline bind point used by this command (https://vulkan.lunarg.com/doc/view/1.3.211.0/windows/1.3-extensions/vkspec.html#VUID-vkCmdDraw-None-02699)
``

**Caused by not writing full capacity of a descriptor set.**