### PR TITLE
Improve cursor capture handling

### DIFF
--- a/src/atlas/mod.rs
+++ b/src/atlas/mod.rs
@@ -1555,7 +1555,7 @@ impl AtlasImage {
             (self.index + 1) as AtlasImageID,
             sub_img_id,
         );
-        
+
         self.sub_imgs.insert(sub_img_id, sub_img);
         Ok(coords)
     }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -164,6 +164,7 @@ pub enum InputEvent {
     Focus { win: BstWindowID },
     FocusLost { win: BstWindowID },
     Motion { x: f32, y: f32 },
+    CursorCapture { win: BstWindowID, captured: bool },
 }
 
 /// An error that is returned by various `Input` related methods.

--- a/src/input/proc/press.rs
+++ b/src/input/proc/press.rs
@@ -131,7 +131,7 @@ pub(in crate::input) fn press(
             }
         }
 
-        if pass_bin_event {
+        if pass_bin_event && !window_state.is_cursor_captured() {
             // Check Bin Focus
             if key == BIN_FOCUS_KEY {
                 if let Some((old_bin_id_op, new_bin_id_op)) =

--- a/src/input/proc/scroll.rs
+++ b/src/input/proc/scroll.rs
@@ -51,6 +51,10 @@ pub(in crate::input) fn scroll(
                         Some((*weight, 0, *hook_id, hook))
                     },
                     InputHookTargetID::Bin(hook_bin) => {
+                        if window_state.is_cursor_captured() {
+                            return None;
+                        }
+
                         let mut inside_i_op: Option<usize> = None;
 
                         for (i, inside_id) in inside_bin_ids.iter().enumerate() {

--- a/src/input/state.rs
+++ b/src/input/state.rs
@@ -18,6 +18,7 @@ pub struct WindowState {
     cursor_pos: [f32; 2],
     focused: bool,
     cursor_inside: bool,
+    cursor_captured: bool,
 }
 
 impl WindowState {
@@ -29,6 +30,7 @@ impl WindowState {
             cursor_pos: [0.0; 2],
             focused: true,
             cursor_inside: true,
+            cursor_captured: false,
         }
     }
 
@@ -106,6 +108,15 @@ impl WindowState {
         }
     }
 
+    pub(in crate::input) fn update_cursor_captured(&mut self, captured: bool) -> bool {
+        if self.cursor_captured != captured {
+            self.cursor_captured = captured;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Returns the `BstWindowID` this state corresponds to.
     pub fn window_id(&self) -> BstWindowID {
         self.window_id
@@ -119,6 +130,10 @@ impl WindowState {
     /// Returns `true` if the cursor is inside.
     pub fn is_cursor_inside(&self) -> bool {
         self.cursor_inside
+    }
+
+    pub fn is_cursor_captured(&self) -> bool {
+        self.cursor_captured
     }
 
     /// Returns the `BinID` of the currently focused `Bin`.

--- a/src/interface/bin/mod.rs
+++ b/src/interface/bin/mod.rs
@@ -1481,7 +1481,7 @@ impl Bin {
             b: 0.0,
             a: 0.0,
         });
-        
+
         let mut back_color = style.back_color.clone().unwrap_or(Color {
             r: 0.0,
             b: 0.0,

--- a/src/window/winit.rs
+++ b/src/window/winit.rs
@@ -57,19 +57,43 @@ impl BasaltWindow for WinitWindow {
     }
 
     fn capture_cursor(&self) {
+        let basalt = self
+            .basalt
+            .lock()
+            .deref()
+            .clone()
+            .expect("Window doesn't have access to Basalt!");
+
         self.inner.set_cursor_visible(false);
         self.inner
             .set_cursor_grab(winit_ty::CursorGrabMode::Confined)
             .unwrap();
         self.cursor_captured.store(true, atomic::Ordering::SeqCst);
+
+        basalt.input_ref().send_event(InputEvent::CursorCapture {
+            win: self.id,
+            captured: true,
+        });
     }
 
     fn release_cursor(&self) {
+        let basalt = self
+            .basalt
+            .lock()
+            .deref()
+            .clone()
+            .expect("Window doesn't have access to Basalt!");
+
         self.inner.set_cursor_visible(true);
         self.inner
             .set_cursor_grab(winit_ty::CursorGrabMode::None)
             .unwrap();
         self.cursor_captured.store(false, atomic::Ordering::SeqCst);
+
+        basalt.input_ref().send_event(InputEvent::CursorCapture {
+            win: self.id,
+            captured: false,
+        });
     }
 
     fn cursor_captured(&self) -> bool {


### PR DESCRIPTION
This fixes some issues around events being received onto bins when the cursor was captured.

#### Upon Capture:
- `Bin` `on_hold` events are stopped.
- `Bin` `on_release` are called if the keys were active.
- `Bin` `on_leave` are called if cursor was inside at the time of capture.
- `Bin` `on_focus_lost` are called if the `Bin` was focused.
  - Upon cursor release, `Bin` will not be automatically refocused.
- Window `on_cursor` will have its state reset.

#### Upon Release:
- `Bin` `on_enter` will be called if the cursor is now inside.
- `on_cursor` will be emitted if the cursor even if the cursor didn't move.
