### PR TITLE
impl `Clipboard`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ vulkano = "0.35"
 vulkano-shaders = "0.35"
 vulkano-taskgraph = "0.35"
 unicode-segmentation = "1"
+arboard = { version = "3", optional = true }
 
 [dependencies.cosmic-text]
 version = "0.14"
@@ -48,9 +49,10 @@ default-features = false
 features = ["rwh_06", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 
 [features]
-default = ["image_decode", "image_download"]
+default = ["image_decode", "image_download", "clipboard"]
 # Removes the #[must_use] attribute from BinStyleValidation and uses the debug method when it drops.
 style_validation_debug_on_drop = []
 image_decode = ["dep:image"]
 image_download = ["image_decode", "dep:curl", "dep:url"]
+clipboard = ["dep:arboard"]
 deadlock_detection = ["parking_lot/deadlock_detection"]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -13,6 +13,7 @@ pub enum ClipboardItem {
 }
 
 impl ClipboardItem {
+    #[cfg_attr(not(feature = "clipboard"), allow(dead_code))]
     fn os_hash(&self) -> u64 {
         let mut hasher = foldhash::quality::FixedState::with_seed(0).build_hasher();
 
@@ -56,6 +57,7 @@ struct State {
 }
 
 struct StoredClipboardItem {
+    #[cfg_attr(not(feature = "clipboard"), allow(dead_code))]
     os_hash: Option<u64>,
     inner: ClipboardItem,
 }
@@ -83,6 +85,7 @@ impl Clipboard {
 
     /// Obtain the value within the clipboard.
     pub fn get(&self) -> Option<ClipboardItem> {
+        #[cfg_attr(not(feature = "clipboard"), allow(unused_mut))]
         let mut state = self.state.lock();
 
         #[cfg(feature = "clipboard")]

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,158 @@
+//! Clipboard related objects
+
+use std::hash::{BuildHasher, Hash, Hasher};
+
+use parking_lot::Mutex;
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+/// An item that may be stored within the clipboard.
+pub enum ClipboardItem {
+    PlainText(String),
+    // TODO: RichText & Images?
+}
+
+impl ClipboardItem {
+    fn os_hash(&self) -> u64 {
+        let mut hasher = foldhash::quality::FixedState::with_seed(0).build_hasher();
+
+        match self {
+            Self::PlainText(text) => text.hash(&mut hasher),
+        }
+
+        hasher.finish()
+    }
+}
+
+impl From<&str> for ClipboardItem {
+    fn from(from: &str) -> Self {
+        Self::PlainText(from.to_string())
+    }
+}
+
+impl From<String> for ClipboardItem {
+    fn from(from: String) -> Self {
+        Self::PlainText(from)
+    }
+}
+
+impl From<&String> for ClipboardItem {
+    fn from(from: &String) -> Self {
+        Self::PlainText(from.clone())
+    }
+}
+
+/// Object for accessing the clipboard.
+///
+/// **Note:** for interaction with the OS's clipboard, the `clipboard` feature msut be enabled.
+pub struct Clipboard {
+    state: Mutex<State>,
+}
+
+struct State {
+    #[cfg(feature = "clipboard")]
+    os_clipboard: Option<arboard::Clipboard>,
+    stored_item: Option<StoredClipboardItem>,
+}
+
+struct StoredClipboardItem {
+    os_hash: Option<u64>,
+    inner: ClipboardItem,
+}
+
+impl Clipboard {
+    pub(crate) fn new() -> Self {
+        #[cfg(feature = "clipboard")]
+        {
+            Self {
+                state: Mutex::new(State {
+                    os_clipboard: arboard::Clipboard::new().ok(),
+                    stored_item: None,
+                }),
+            }
+        }
+        #[cfg(not(feature = "clipboard"))]
+        {
+            Self {
+                state: Mutex::new(State {
+                    stored_item: None,
+                }),
+            }
+        }
+    }
+
+    /// Obtain the value within the clipboard.
+    pub fn get(&self) -> Option<ClipboardItem> {
+        let mut state = self.state.lock();
+
+        #[cfg(feature = "clipboard")]
+        {
+            // TODO: As ClipboardItem gets more variants support other types of clipboard data.
+
+            // NOTE: This attempts to get the os's clipboard and compares into the hash of the
+            //       stored clipboard item. The hash is of how that item would be stored on the os.
+            //       If the hash is the same, returns the stored value instead. This allows for
+            //       basalt specific types in the future, that may be applicable for the os
+            //       clipboard, but not the same as what would be created from the os clipboard.
+
+            if let Some(os_clipboard) = state.os_clipboard.as_mut() {
+                if let Ok(text) = os_clipboard.get_text() {
+                    if let Some(stored_item) = state.stored_item.as_ref() {
+                        if let Some(stored_os_hash) = stored_item.os_hash {
+                            let mut hasher =
+                                foldhash::quality::FixedState::with_seed(0).build_hasher();
+                            text.hash(&mut hasher);
+                            let os_hash = hasher.finish();
+
+                            if os_hash == stored_os_hash {
+                                return Some(stored_item.inner.clone());
+                            }
+                        }
+                    }
+
+                    state.stored_item = None;
+                    return Some(ClipboardItem::PlainText(text));
+                }
+            }
+        }
+
+        state.stored_item.as_ref().map(|item| item.inner.clone())
+    }
+
+    /// Obtain the value within the clipboard.
+    pub fn set<I>(&self, item: I)
+    where
+        I: Into<ClipboardItem>,
+    {
+        let item = item.into();
+        let mut state = self.state.lock();
+
+        let os_hash = {
+            #[cfg(feature = "clipboard")]
+            {
+                match state.os_clipboard.as_mut() {
+                    Some(os_clipboard) => {
+                        match &item {
+                            ClipboardItem::PlainText(text) => {
+                                match os_clipboard.set_text(text.clone()) {
+                                    Ok(_) => Some(item.os_hash()),
+                                    Err(_) => None,
+                                }
+                            },
+                        }
+                    },
+                    None => None,
+                }
+            }
+            #[cfg(not(feature = "clipboard"))]
+            {
+                None
+            }
+        };
+
+        state.stored_item = Some(StoredClipboardItem {
+            os_hash,
+            inner: item,
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::collapsible_else_if)]
 
+pub mod clipboard;
 pub mod image;
 pub mod input;
 pub mod interface;
@@ -33,6 +34,7 @@ mod vko {
     pub use vulkano_taskgraph::resource::Resources;
 }
 
+use crate::clipboard::Clipboard;
 use crate::image::ImageCache;
 use crate::input::Input;
 use crate::interface::Interface;
@@ -286,6 +288,7 @@ pub struct Basalt {
     interval: Arc<Interval>,
     image_cache: Arc<ImageCache>,
     window_manager: Arc<WindowManager>,
+    clipboard: Clipboard,
     wants_exit: AtomicBool,
     config: BasaltConfig,
 }
@@ -658,6 +661,7 @@ impl Basalt {
                 interval,
                 image_cache: Arc::new(ImageCache::new()),
                 window_manager,
+                clipboard: Clipboard::new(),
                 wants_exit: AtomicBool::new(false),
                 config: BasaltConfig {
                     window_ignore_dpi,
@@ -703,6 +707,11 @@ impl Basalt {
     /// Obtain a reference of `Input`
     pub fn input_ref(&self) -> &Input {
         &self.input
+    }
+
+    /// Obtain a reference of [`Clipboard`]
+    pub fn clipboard(&self) -> &Clipboard {
+        &self.clipboard
     }
 
     /// Obtain a copy of `Arc<Interval>`


### PR DESCRIPTION
- Implements a basic clipboard store, that allows optional interaction with the OS clipboard.
- Removes widget specific clipboard stores.
- Integrated for widgets that use the `text_hooks`: `SpinButton`, `TextEntry`, `TextEditor`, and `CodeEditor`.
